### PR TITLE
Add totem selector (+ Fix being unable to add items)

### DIFF
--- a/Scripts/Popups/MainPopup/Act1/Act1.cs
+++ b/Scripts/Popups/MainPopup/Act1/Act1.cs
@@ -1,5 +1,8 @@
 ﻿using DebugMenu.Scripts.Acts;
+using BepInEx;
+using DebugMenu.Scripts.Popups;
 using DiskCardGame;
+using InscryptionAPI.Card;
 using UnityEngine;
 
 namespace DebugMenu.Scripts.Act1;
@@ -9,6 +12,8 @@ public class Act1 : BaseAct
     public static List<CardInfo> lastUsedStarterDeck = null;
     public static bool SkipNextNode = false;
     public static bool ActivateAllMapNodesActive = false;
+    public static Tribe SelectedTotemTribe = Tribe.None;
+    public static Ability SelectedTotemAbility = Ability.None;
 
     public Act1(DebugWindow window) : base(window)
     {
@@ -31,6 +36,7 @@ public class Act1 : BaseAct
 
         DrawCurrencyGUI();
         DrawItemsGUI();
+        DrawTotemGUI();
         Window.Padding();
 
         if (Window.Button("Replenish Candles"))
@@ -73,6 +79,94 @@ public class Act1 : BaseAct
 
             if (Window.Button("-5"))
                 RunState.Run.currency = Mathf.Max(0, RunState.Run.currency - 5);
+        }
+    }
+    private void DrawTotemGUI()
+    {
+        Window.LabelHeader("Totem");
+        string currentTotemTopName = Enum.GetName(typeof(Tribe), SelectedTotemTribe); ;
+        string currentTotemBottomName = AbilitiesUtil.GetInfo(SelectedTotemAbility) == null ? "None" : AbilitiesUtil.GetInfo(SelectedTotemAbility).rulebookName;
+        if (currentTotemTopName.IsNullOrWhiteSpace())
+            currentTotemTopName = TribeManager.NewTribes.First((TribeManager.TribeInfo tribe) => { return tribe.tribe == SelectedTotemTribe; }).name;
+        using (Window.HorizontalScope(2))
+        {
+            ButtonListPopup.OnGUI<ButtonListPopup>(Window, "Tribe: " + currentTotemTopName, "Change Totem Tribe", () =>
+            {
+                List<Tribe> allTribes = [Tribe.None, Tribe.Squirrel, Tribe.Bird, Tribe.Canine, Tribe.Hooved, Tribe.Reptile, Tribe.Insect];
+                allTribes.AddRange(TribeManager.NewTribesTypes);
+
+                List<string> names = new(allTribes.Count);
+                List<string> values = new(allTribes.Count);
+
+                for (int i = 0; i < allTribes.Count; i++)
+                {
+                    string name = null;
+                    if (TribeManager.IsCustomTribe(allTribes[i]))
+                    {
+                        TribeManager.TribeInfo iTribe = TribeManager.NewTribes.First((TribeManager.TribeInfo tribe) => { return tribe.tribe == allTribes[i]; });
+                        name = iTribe.guid + "_" + iTribe.name;
+                    }
+                    else
+                    {
+                        name = Enum.GetName(typeof(Tribe), allTribes[i]);
+                    }
+                    names.Add(name);
+                    values.Add(name);
+                }
+                return new Tuple<List<string>, List<string>>(names, values);
+            }, (int chosenIndex, string chosenValue, List<string> index) =>
+            {
+                Tribe chosenTribe = Tribe.None;
+                Enum.TryParse<Tribe>(chosenValue, false, out chosenTribe);
+                if (chosenTribe == Tribe.None && chosenValue != "None")
+                {
+                    chosenTribe = TribeManager.NewTribes.First((TribeManager.TribeInfo tribe) => { return tribe.guid + "_" + tribe.name == chosenValue; }).tribe;
+                }
+                SelectedTotemTribe = chosenTribe;
+            });
+
+            ButtonListPopup.OnGUI<ButtonListPopup>(Window, "Sigil: " + currentTotemBottomName, "Change Totem Sigil", () =>
+            {
+                List<AbilityManager.FullAbility> allAbilities = AbilityManager.AllAbilities;
+
+                List<string> names = new(allAbilities.Count);
+                List<string> values = new(allAbilities.Count);
+
+                for (int i = 0; i < allAbilities.Count; i++)
+                {
+                    names.Add(allAbilities[i].Info.rulebookName + "\n(" + allAbilities[i].Info.name + ")");
+                    values.Add(allAbilities[i].Info.name);
+                }
+                return new Tuple<List<string>, List<string>>(names, values);
+            }, (int chosenIndex, string chosenValue, List<string> index) =>
+            {
+                Ability chosenAbility = Ability.None;
+                if (chosenAbility == Ability.None && chosenValue != "None")
+                {
+                    chosenAbility = AbilityManager.AllAbilities.First((AbilityManager.FullAbility ability) => { return ability.Info.name == chosenValue; }).Id;
+                }
+                SelectedTotemAbility = chosenAbility;
+            });
+        }
+        if (Window.Button("Set Totem"))
+        {
+            RunState.Run.totems.Clear();
+            if (Part1ItemsManager.Instance.Totems.Count > 0)
+            {
+                Totem existingTotem = Part1ItemsManager.Instance.Totems[0];
+                UnityEngine.Object.DestroyImmediate(existingTotem.gameObject);
+                existingTotem = null;
+            }
+            if (SelectedTotemAbility != Ability.None && SelectedTotemTribe != Tribe.None)
+            {
+                TotemDefinition newTotem = new()
+                {
+                    tribe = SelectedTotemTribe,
+                    ability = SelectedTotemAbility
+                };
+                RunState.Run.totems.Add(newTotem);
+            }
+            ItemsManager.Instance.UpdateItems(true);
         }
     }
 

--- a/Scripts/Popups/MainPopup/BaseAct.cs
+++ b/Scripts/Popups/MainPopup/BaseAct.cs
@@ -84,7 +84,7 @@ public abstract class BaseAct
     public static void OnChoseButtonCallback(int chosenIndex, string chosenValue, List<string> inventoryIndex)
     {
         List<string> currentItems = GetConsumables();
-        for (int i = 0; i < currentItems.Count; i++)
+        for (int i = 0; i < (SaveManager.SaveFile.IsPart3 ? 3 : RunState.Run.MaxConsumables); i++)
         {
             if (int.TryParse(inventoryIndex[0], out int e) && i != e) {
                 continue;


### PR DESCRIPTION
I added a totem selector to the Act 1 GUI that lets the user choose a tribe and sigil and then spawn that totem (replacing any current totem if one exists). I've tested it to make sure it works with modded tribes and sigils.
I also fixed a bug I noticed while using the mod where the item selector couldn't add an item to an empty slot. I've tested this fix in Kaycee's Mod and it seems to resolve the issue.